### PR TITLE
fix: Use absolute paths for loading configuration files

### DIFF
--- a/mcp_open_client/config_utils.py
+++ b/mcp_open_client/config_utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Dict, Any, Optional
 from nicegui import app
 
@@ -6,9 +7,14 @@ def load_initial_config_from_files():
     """Load initial configuration from files into user storage (one-time operation)"""
     configs_loaded = {}
     
+    # Get the directory where this module is located
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    settings_dir = os.path.join(current_dir, 'settings')
+    
     # Load MCP configuration (only MCP servers)
+    mcp_config_path = os.path.join(settings_dir, 'mcp-config.json')
     try:
-        with open('mcp_open_client/settings/mcp-config.json', 'r', encoding='utf-8') as f:
+        with open(mcp_config_path, 'r', encoding='utf-8') as f:
             mcp_file_config = json.load(f)
             configs_loaded['mcp-config'] = mcp_file_config
             print("Loaded MCP servers configuration from mcp-config.json")
@@ -17,8 +23,9 @@ def load_initial_config_from_files():
         configs_loaded['mcp-config'] = {"mcpServers": {}}
 
     # Load user settings (API settings) from user-settings.json
+    user_settings_path = os.path.join(settings_dir, 'user-settings.json')
     try:
-        with open('mcp_open_client/settings/user-settings.json', 'r', encoding='utf-8') as f:
+        with open(user_settings_path, 'r', encoding='utf-8') as f:
             user_settings_file = json.load(f)
             configs_loaded['user-settings'] = user_settings_file
             print("Loaded user settings from user-settings.json")


### PR DESCRIPTION
Fixes configuration file loading issue when running mcp-open-client from different directories.
**Problem:**
- Configuration files (mcp-config.json and user-settings.json) could not be loaded when running the application from directories other than the project root
- This caused 'Could not load MCP config' and 'Could not load user settings' errors
**Solution:**
- Replace relative paths with absolute paths based on the module location
- Use os.path.dirname(os.path.abspath(__file__)) to get the module directory
- Build absolute paths to the settings directory and configuration files
**Testing:**
- Ô£à Application now starts without configuration errors
- Ô£à Configuration files are loaded correctly from any working directory
- Ô£à No more 'Could not load' warnings in the console output
Resolves configuration loading issues and ensures consistent behavior regardless of execution context.